### PR TITLE
fix(paths): add leading slashes to product, categories and image urls

### DIFF
--- a/code/Model/Api2/Category.php
+++ b/code/Model/Api2/Category.php
@@ -31,9 +31,9 @@ class Clockworkgeek_Extrarestful_Model_Api2_Category extends Clockworkgeek_Extra
         }
         if ($this->isReadable('url')) {
             $categoryUrl = $category->getUrlModel()->getCategoryUrl($category);
-            $category->setUrl(str_replace(Mage::getBaseUrl(), '', $categoryUrl));
+            $category->setUrl(str_replace(Mage::getBaseUrl(), '/', $categoryUrl));
         }
-        $category->setImageUrl('media/catalog/category/' . $category->getImage());
+        $category->setImageUrl('/media/catalog/category/' . $category->getImage());
         $this->_prepareCategory($category);
 
         if ($lastMod = strtotime($category->getUpdatedAt())) {
@@ -69,7 +69,7 @@ class Clockworkgeek_Extrarestful_Model_Api2_Category extends Clockworkgeek_Extra
                 // prevent accidentally starting session for SID check
                 '_nosid' => true
             ));
-            $category->setUrl(str_replace(Mage::getBaseUrl(), '', $url));
+            $category->setUrl(str_replace(Mage::getBaseUrl(), '/', $url));
         }
     }
 
@@ -102,7 +102,7 @@ class Clockworkgeek_Extrarestful_Model_Api2_Category extends Clockworkgeek_Extra
         }
 
         if ($this->isReadable('image_url')) {
-            $dir = 'media/catalog/category/';
+            $dir = '/media/catalog/category/';
             $method = method_exists($categories, 'addExpressionAttributeToSelect') ? 'addExpressionAttributeToSelect' : 'addExpressionFieldToSelect';
             $categories->$method('image_url', "CONCAT('{$dir}', {{image}})", 'image');
             // map is only used by flat tables, doesn't hurt EAV tables

--- a/code/Model/Api2/Product.php
+++ b/code/Model/Api2/Product.php
@@ -180,7 +180,7 @@ class Clockworkgeek_Extrarestful_Model_Api2_Product extends Clockworkgeek_Extrar
             if ($imageUrl == 'no_selection' || !$imageUrl) {
                 $imageUrl = '';
             } else {
-                $imageUrl = 'media/catalog/product/' . $imageUrl;
+                $imageUrl = '/media/catalog/product/' . $imageUrl;
             }
             $product->setImageUrl((string) $imageUrl);
         }
@@ -218,7 +218,7 @@ class Clockworkgeek_Extrarestful_Model_Api2_Product extends Clockworkgeek_Extrar
                 '_nosid' => true
             ));
 
-            $product->setUrl(str_replace(Mage::getBaseUrl(), '', $productUrl));
+            $product->setUrl(str_replace(Mage::getBaseUrl(), '/', $productUrl));
         }
         Mage::dispatchEvent('clockworkgeek_api_prepare_product_after', [
             'product' => $product,


### PR DESCRIPTION
to prevent regression introduced in
9d0df239706de11e21a76bc712dad7d532bd0822 when removeng the base url